### PR TITLE
Added group requirements info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
 ## Autorun at boot
-After you have cloned this repo in `/opt` run the following command:
+Once you cloned this repo under `/opt` run the following commands:
 
-    $sudo cp docker-compose@.service /lib/systemd/system
-    $sudo systemctl daemon-reload
-    $sudo systemctl start docker-compose@SambaSharesVM.service
-    $sudo systemctl enable docker-compose@SambaSharesVM.service
+	$ sudo cp docker-compose@.service /lib/systemd/system
+	$ sudo systemctl daemon-reload
 
-If docker-compose can't be found, check if is in `/usr/bin/docker-compose`. If not, install it or create a symbolic link `ln -s $(which docker-compose) /usr/bin/docker-compose`.
+In order to be able to manage the files in your shared folder, `owner:group` have to match the ones set in the container `smbuser:smbshare`
+respectively `UID 100` and `GUID 101`.
+
+To do so run:
+
+	$ sudo groupadd -g 101 smb
+	$ sudo gpasswd -A $USER smb
+
+NB: For the changes to take effect you need to either logout/reboot your system or start a new login shell
+
+	$ sudo systemctl start docker-compose@SambaSharesVM.service
+	$ sudo systemctl enable docker-compose@SambaSharesVM.service
+
+If you get the following error message: 
+docker-compose not found, make sure it's under `/usr/bin/docker-compose`. 
+If not, install it (according to your distro) or create a symbolic link for it
+`ln -s $(which docker-compose) /usr/bin/docker-compose`.
+


### PR DESCRIPTION
The bind mounted folder in the container is owned by smbuser:smb
respectively UID 100 and GUID 101 

So in order to operate on files under the shared folder the current user has to be part of a group with GUID 101.